### PR TITLE
updated repo url (last version generated an error)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"vbb-hafas":					"^0.5.0",
 		"vbb-stations-autocomplete":	"^0.4.2",
 		"q":							"^1.4.1",
-		"inquirer":						"ssh://git@github.com:derhuerst/Inquirer.js.git#autocomplete",
+		"inquirer":						"derhuerst/Inquirer.js#autocomplete",
 		"chalk":						"^1.1.0",
 		"vbb-util":						"^0.5.1",
 		"moment":						"^2.10.6",


### PR DESCRIPTION
npm http 304 https://registry.npmjs.org/inquirer
npm ERR! Error: No compatible version found: inquirer@'ssh://git@github.com:derhuerst/Inquirer.js.git#autocomplete'
npm ERR! Valid install targets:
npm ERR! ["0.1.0","0.1.1","0.1.2","0.1.3","0.1.4","0.1.5","0.1.6","0.1.7","0.1.8","0.1.9","0.2.0","0.2.1","0.1.11","0.1.12","0.2.2","0.2.3","0.2.4","0.2.5","0.3.0","0.3.1","0.3.2","0.3.3","0.3.4","0.3.5","0.4.0","0.4.1","0.5.0","0.5.1","0.6.0","0.7.1","0.7.2","0.7.3","0.8.0","0.8.2","0.8.3","0.8.4","0.8.5","0.9.0","0.10.0","0.10.1"]
npm ERR!     at installTargetsError (/usr/share/npm/lib/cache.js:719:10)
npm ERR!     at /usr/share/npm/lib/cache.js:638:10
npm ERR!     at saved (/usr/share/npm/node_modules/npm-registry-client/lib/get.js:142:7)
npm ERR!     at /usr/lib/nodejs/graceful-fs/polyfills.js:133:7
npm ERR!     at Object.oncomplete (fs.js:107:15)
